### PR TITLE
Added TypeScript declaration to be used with import

### DIFF
--- a/src/json2mjml.d.ts
+++ b/src/json2mjml.d.ts
@@ -1,0 +1,1 @@
+declare module 'json2mjml';


### PR DESCRIPTION
I'm adding this required file for make imports possible on servers,:
```js
import json2mjml from 'json2mjml'
```

Otherwise they are not able to get it as an external dependency and displays this error:
`Could not find a declaration file for module 'json2mjml'.`

I'm not sure why, but instead of being able to use the example in the README.md:
```js
const output = json2mjml(input)
```
I have to use:
```js
const output = json2mjml.default(input)
```

